### PR TITLE
Fix player stuck and wrong angle tracing

### DIFF
--- a/Assets/Animations/Player (New)/PlayerAnimation.controller
+++ b/Assets/Animations/Player (New)/PlayerAnimation.controller
@@ -518,7 +518,7 @@ AnimatorStateTransition:
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -7989310648838548133}
   m_Solo: 0
-  m_Mute: 0
+  m_Mute: 1
   m_IsExit: 0
   serializedVersion: 3
   m_TransitionDuration: 0.25
@@ -551,6 +551,9 @@ AnimatorStateTransition:
     m_EventTreshold: 0
   - m_ConditionMode: 2
     m_ConditionEvent: OnPortalInteract
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: OnEndFall
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -2038994973239420554}
@@ -686,6 +689,7 @@ AnimatorStateMachine:
   - {fileID: 360760326150636834}
   - {fileID: 5015933849129939511}
   - {fileID: -3916416045794072747}
+  - {fileID: 3327382111895223233}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
@@ -720,6 +724,40 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &3327382111895223233
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: OnEndFall
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: OnIdle
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: OnMove
+    m_EventTreshold: 0
+  - m_ConditionMode: 3
+    m_ConditionEvent: YSpeed
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -7989310648838548133}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 0
 --- !u!1101 &3531000897766038829
 AnimatorStateTransition:
   m_ObjectHideFlags: 1

--- a/Assets/Resources/Prefabs/Gameplay/Gameplay-Character.prefab
+++ b/Assets/Resources/Prefabs/Gameplay/Gameplay-Character.prefab
@@ -55,7 +55,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1874046904873477730}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.024, y: -2.987, z: 0}
+  m_LocalPosition: {x: -0.024, y: -2.989, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -148,7 +148,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1874046905199477736}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.024, y: -3.514, z: 0}
+  m_LocalPosition: {x: -0.024, y: -3.521, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -288,7 +288,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _checkRadius: 0.25
-  _circleForGround: 0.54
+  _circleForGround: 0.542
   _ground: {fileID: 1874046904873477729}
   _normalChecker: {fileID: 1874046905199477743}
   _ceil: {fileID: 1874046904939670345}
@@ -304,7 +304,7 @@ MonoBehaviour:
   _jumpForce: 20
   _fallMultiplier: 4
   _playerAnimator: {fileID: 852962807448629436}
-  _rangeNearGround: 3
+  _rangeNearGround: 1.5
 --- !u!70 &1874046906382160644
 CapsuleCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Gameplay/Gameplay-Character.prefab
+++ b/Assets/Resources/Prefabs/Gameplay/Gameplay-Character.prefab
@@ -55,7 +55,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1874046904873477730}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.026, y: -3.011, z: 0}
+  m_LocalPosition: {x: -0.024, y: -2.987, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -133,7 +133,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1874046905199477743}
-  - component: {fileID: 1874046905199477742}
   m_Layer: 0
   m_Name: TopDown-Check
   m_TagString: Untagged
@@ -149,39 +148,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1874046905199477736}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.024, y: -3.514, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1874046906382160645}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &1874046905199477742
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1874046905199477736}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 4}
-  m_EdgeRadius: 0
 --- !u!1 &1874046906382160641
 GameObject:
   m_ObjectHideFlags: 0
@@ -315,7 +288,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _checkRadius: 0.25
+  _circleForGround: 0.54
   _ground: {fileID: 1874046904873477729}
+  _normalChecker: {fileID: 1874046905199477743}
   _ceil: {fileID: 1874046904939670345}
   _rightHand: {fileID: 1874046904854633787}
   _leftHand: {fileID: 1874046904934106706}
@@ -423,6 +398,10 @@ MonoBehaviour:
   _varOnEndFall: OnEndFall
   _varYSpeed: YSpeed
   _varOnMove: OnMove
+  _varOnPull: OnPull
+  _varOnPush: OnPush
+  _varOnPortalInteract: OnPortalInteract
+  _varOnWaitInteract: OnWaitInteract
 --- !u!114 &4406172908942543950
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -435,11 +414,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 79996d5419af2364f9208a3db578788e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _layerMask:
-    serializedVersion: 2
-    m_Bits: 136
-  _distance: 1.2
-  _radius: 0.5
 --- !u!1 &1874046906486841755
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Dummy-Character-Backup.unity
+++ b/Assets/Scenes/Dummy-Character-Backup.unity
@@ -264,11 +264,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1874046906382160645, guid: e083cf94e9bcaca42b478d9cd2ee3657, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -36.5
+      value: -39.66
       objectReference: {fileID: 0}
     - target: {fileID: 1874046906382160645, guid: e083cf94e9bcaca42b478d9cd2ee3657, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -29.1
+      value: -27.4
       objectReference: {fileID: 0}
     - target: {fileID: 1874046906382160645, guid: e083cf94e9bcaca42b478d9cd2ee3657, type: 3}
       propertyPath: m_LocalPosition.z
@@ -508,7 +508,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 303913227}
   m_LocalRotation: {x: -1e-45, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -36.5, y: -29.1, z: -10}
+  m_LocalPosition: {x: -39.66, y: -27.4, z: -10}
   m_LocalScale: {x: 1.4126525, y: 1.3322172, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2887,7 +2887,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1937507288}
   m_LocalRotation: {x: -1e-45, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -36.5, y: -29.1, z: -10}
+  m_LocalPosition: {x: -39.66, y: -27.4, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:

--- a/Assets/Scenes/Dummy-Character-Backup.unity
+++ b/Assets/Scenes/Dummy-Character-Backup.unity
@@ -250,6 +250,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1874046905199477736, guid: e083cf94e9bcaca42b478d9cd2ee3657, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1874046906382160641, guid: e083cf94e9bcaca42b478d9cd2ee3657, type: 3}
       propertyPath: m_Name
       value: Gameplay-Character
@@ -2708,6 +2712,117 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &1853847494
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1853847497}
+  - component: {fileID: 1853847496}
+  - component: {fileID: 1853847495}
+  m_Layer: 3
+  m_Name: Square (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &1853847495
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853847494}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!212 &1853847496
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853847494}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1853847497
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853847494}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -40.8676, y: -33.7665, z: 0}
+  m_LocalScale: {x: 2.0649204, y: 3.067373, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 24
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1937507288
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Gameplay/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Gameplay/Player/PlayerMovement.cs
@@ -300,8 +300,9 @@ namespace Comma.Gameplay.Player
 
             if (_playerAnimator.YSpeed == .5f)
             {
-                RaycastHit2D nearGround = IsCollide(_ground.position, Vector2.down, _rangeNearGround);
-                if (nearGround && !_wasGrounded)
+                RaycastHit2D nearGround = IsCollide(_normalChecker.position, Vector2.down, _rangeNearGround);
+                //Debug.Log(nearGround.collider, nearGround.collider);
+                if (nearGround.collider !=null && !_wasGrounded)
                 {
                     _playerAnimator.YSpeed = 1f;
                     _playerAnimator.EndFall = true;
@@ -336,7 +337,7 @@ namespace Comma.Gameplay.Player
                 layerToCheck = 0;
             Physics2D.IgnoreLayerCollision(_layerValue[0], _layerValue[1], false);
             Physics2D.IgnoreLayerCollision(_layerValue[1], _layerValue[0], false);
-            RaycastHit2D hit = Physics2D.Raycast(_ground.position,
+            RaycastHit2D hit = Physics2D.Raycast(_normalChecker.position,
                 Vector2.down, _checkRadius, _groundLayers[layerToCheck]);
             Physics2D.IgnoreLayerCollision(_layerValue[0], _layerValue[1], true);
             Physics2D.IgnoreLayerCollision(_layerValue[1], _layerValue[0], true);
@@ -419,6 +420,7 @@ namespace Comma.Gameplay.Player
         {
             Gizmos.color = Color.red;
             Gizmos.DrawWireSphere(_ground.position, _circleForGround);
+            //Gizmos.DrawRay(_normalChecker.position, Vector2.down);
         }
 
         private RaycastHit2D IsCollide(Vector3 from, Vector2 direction, float distance)

--- a/Assets/Scripts/Gameplay/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Gameplay/Player/PlayerMovement.cs
@@ -24,8 +24,10 @@ namespace Comma.Gameplay.Player
         [SerializeField]
         [Range(0.2f, 0.35f)]
         private float _checkRadius = .25f;
+        [SerializeField] float _circleForGround = .52f;
         [SerializeField]
         private Transform _ground;
+        [SerializeField] private Transform _normalChecker;
         [SerializeField]
         private Transform _ceil;
         [SerializeField]
@@ -368,33 +370,55 @@ namespace Comma.Gameplay.Player
         private bool IsGrounded()
         {
 
-
-            RaycastHit2D tryToCheckGround = IsCollide(_ground.position, Vector2.down, _checkRadius);
-            if (tryToCheckGround.collider.gameObject != gameObject)
+            // For applying slope velocity
+            RaycastHit2D normalChecker = IsCollide(_normalChecker.position, Vector2.down, _checkRadius);
+            if (normalChecker)
             {
-                _currentPlatformDegree = tryToCheckGround.normal;
-                return tryToCheckGround;
+                _currentPlatformDegree = normalChecker.normal;
+
             }
             else
             {
-                Collider2D[] colls = Physics2D.OverlapCircleAll(_ground.position, .52f, _groundLayers[_currentLayer]);
-                if (colls.Length <= 0) return false;
-                for (int i =0; i < colls.Length; i++)
+                _currentPlatformDegree = new(0, 1);
+            }
+
+            // Checking Ground
+            Collider2D[] overlaps = Physics2D.OverlapCircleAll(_ground.position, _circleForGround, _groundLayers[_currentLayer]);
+            if (overlaps.Length <= 0) return false;
+            for (int i = 0; i < overlaps.Length; i++)
+            {
+                if (!overlaps[i].CompareTag("Player"))
                 {
-                    if (colls[i].gameObject != gameObject)
-                    {
-                        _currentPlatformDegree = new(0, 1);
-                        return true;
-                    }
+                    return true;
                 }
             }
+
+            //RaycastHit2D tryToCheckGround = IsCollide(_ground.position, Vector2.down, _checkRadius);
+            //if (tryToCheckGround.collider.gameObject != gameObject)
+            //{
+            //    _currentPlatformDegree = tryToCheckGround.normal;
+            //    return tryToCheckGround;
+            //}
+            //else
+            //{
+            //    Collider2D[] colls = Physics2D.OverlapCircleAll(_ground.position, .52f, _groundLayers[_currentLayer]);
+            //    if (colls.Length <= 0) return false;
+            //    for (int i =0; i < colls.Length; i++)
+            //    {
+            //        if (colls[i].gameObject != gameObject)
+            //        {
+            //            _currentPlatformDegree = new(0, 1);
+            //            return true;
+            //        }
+            //    }
+            //}
 
             return false;
         }
         private void OnDrawGizmos()
         {
             Gizmos.color = Color.red;
-            Gizmos.DrawWireSphere(_ground.position, .52f);
+            Gizmos.DrawWireSphere(_ground.position, _circleForGround);
         }
 
         private RaycastHit2D IsCollide(Vector3 from, Vector2 direction, float distance)


### PR DESCRIPTION
- Use overlap circle to detect ground, while still using ray cast to get ground slope angle
- Now, player won't be in a jump animation (for a few millisecond) after landing
- Adjust animation logic